### PR TITLE
condor IDTOKEN creation on Analysis Facility hosts

### DIFF
--- a/resources/provisioner/sync_users.sh
+++ b/resources/provisioner/sync_users.sh
@@ -673,9 +673,7 @@ for USER in $USERS_TO_CREATE; do
 			set_af_home_quotas "$USER"
 			set_af_work_quotas "$USER"
 			set_ssh_authorized_keys "$USER" "${HOME_DIR_ROOT}/${USER}" "$(/usr/bin/env echo "$USER_DATA" | jq -r '.public_key')"
-		elif [ "$(hostname -f)" == "head01.af.uchicago.edu" ] || \
-			[ "$(hostname -f)" == "login01.af.uchicago.edu" ] || \
-			[ "$(hostname -f)" == "login02.af.uchicago.edu" ]; then
+		elif [ "$(hostname -f)" == "head01.af.uchicago.edu" ]; then
 			set_condor_token "$USER"
 		else
 			echo "Creating user $USER with uid $USER_ID and groups $USER_GROUPS (No Home)"


### PR DESCRIPTION
add a new function for issuing HTCondor tokens for IDTOKEN authentication type, such that we can split the schedd from the rest of the nodes.

When the script runs on either the central manager or the submit hosts (i.e., hosts that have the pool password), it will issue a new IDTOKEN for this user. We then store that in the user's personal `$HOME/.condor` configuration dir, such that they can submit to the remote schedd and be authenticated with the pool. This also will allow e.. Jupyter notebooks to submit to the pool once we hook in the provisioner.