### PR TITLE
fixed a bug where root user cannot be injected in a fresh database

### DIFF
--- a/src/PersistentStore.cpp
+++ b/src/PersistentStore.cpp
@@ -565,6 +565,7 @@ void PersistentStore::InitializeTables(std::string bootstrapUserFile){
 			log_fatal("Unable to read root user credentials");
 		rootUser.globusID="No Globus ID";
 		rootUser.sshKey="No SSH key";
+		rootUser.x509DN="No X.509 DN";
 		rootUser.unixName="root";
 		rootUser.joinDate=timestamp();
 		rootUser.lastUseTime=timestamp();


### PR DESCRIPTION
On a fresh instance of the server w/ Amazon's self-contained DynamoDB service:
```
[centos@api-dev build]$ ./ci-connect-service --config test.conf 
INFO: [2021-Aug-02 18:25:58.596739 UTC] (TID 140293132298368) Database URL is http://localhost:8000
INFO: [2021-Aug-02 18:25:58.596857 UTC] (TID 140293132298368) Service port is 18080
INFO: [2021-Aug-02 18:25:58.681063 UTC] (TID 140293132298368) Starting database client
INFO: [2021-Aug-02 18:25:58.688852 UTC] (TID 140293132298368) Users table does not exist; creating
INFO: [2021-Aug-02 18:25:58.851817 UTC] (TID 140293132298368) Waiting for table CONNECT_users to reach active status
INFO: [2021-Aug-02 18:25:59.416190 UTC] (TID 140293132298368) Next ID hint: 10000
INFO: [2021-Aug-02 18:25:59.431344 UTC] (TID 140293132298368) Allocated ID 10000
ERROR: [2021-Aug-02 18:25:59.590970 UTC] (TID 140293132298368) Failed to add user record: Supplied AttributeValue is empty, must contain exactly one of the supported datatypes
FATAL: [2021-Aug-02 18:25:59.591048 UTC] (TID 140293132298368) Failed to inject root user
ERROR: [2021-Aug-02 18:25:59.591161 UTC] (TID 140293132298368) Failed to inject root user; deleting users table
terminate called after throwing an instance of 'std::runtime_error'
  what():  Failed to inject root user
Aborted
```

Since the last thing we added was X.509 DN support, I speculated that it was missing in the root user bootstrap, and so I added it. Adding the new field and re-running the bootstrap yields:
```
[centos@api-dev build]$ ./ci-connect-service --config test.conf                                                                                                                                                                      [108/166]
INFO: [2021-Aug-02 18:29:30.328310 UTC] (TID 140039866226816) Database URL is http://localhost:8000
INFO: [2021-Aug-02 18:29:30.328433 UTC] (TID 140039866226816) Service port is 18080
INFO: [2021-Aug-02 18:29:30.409920 UTC] (TID 140039866226816) Starting database client
INFO: [2021-Aug-02 18:29:30.417836 UTC] (TID 140039866226816) Users table does not exist; creating
INFO: [2021-Aug-02 18:29:30.755913 UTC] (TID 140039866226816) Waiting for table CONNECT_users to reach active status
INFO: [2021-Aug-02 18:29:31.353179 UTC] (TID 140039866226816) Next ID hint: 10000
INFO: [2021-Aug-02 18:29:31.366139 UTC] (TID 140039866226816) Allocated ID 10000
INFO: [2021-Aug-02 18:29:31.506121 UTC] (TID 140039866226816) Created users table
INFO: [2021-Aug-02 18:29:31.508507 UTC] (TID 140039866226816) groups table does not exist; creating
INFO: [2021-Aug-02 18:29:31.570375 UTC] (TID 140039866226816) Waiting for table CONNECT_groups to reach active status
INFO: [2021-Aug-02 18:29:32.163750 UTC] (TID 140039866226816) Next ID hint: 5000
INFO: [2021-Aug-02 18:29:32.174109 UTC] (TID 140039866226816) Allocated ID 5000
INFO: [2021-Aug-02 18:29:33.216547 UTC] (TID 140039866226816) Created groups table
INFO: [2021-Aug-02 18:29:33.216576 UTC] (TID 140039866226816) Database client ready
```

Which looks as-expected.