### PR TITLE
`userdel` is too smart

### DIFF
--- a/resources/provisioner/sync_users.sh
+++ b/resources/provisioner/sync_users.sh
@@ -383,12 +383,12 @@ $DISABLED_USERS" | sort > all_users
 for DEFUNCT_USER in $(join -v1 existing_users all_users); do
 	echo "Deleting user $DEFUNCT_USER"
 	if [ ! "$DRY_RUN" ]; then
-		which condor_hold # may not exist
+		which condor_hold >/dev/null 2>&1 # may not exist
 		if [ "$?" -ne 0 ]; then
 			echo "Holding all jobs for user"
 			condor_hold $DEFUNCT_USER
 		fi
-		which crontab # may not exist, esp in containers
+		which crontab >/dev/null 2>&1 # may not exist, esp in containers
 		if [ "$?" -ne 0 ]; then
 			echo "Removing crons for user"
 			crontab -r -u $DEFUNCT_USER

--- a/resources/provisioner/sync_users.sh
+++ b/resources/provisioner/sync_users.sh
@@ -180,12 +180,12 @@ if [ "$DO_WIPE" ]; then
 		for DEFUNCT_USER in $(cat existing_users); do
 			echo "Deleting user $DEFUNCT_USER"
 			if [ ! "$DRY_RUN" ]; then
-				which condor_hold # may not exist
+				which condor_hold >/dev/null 2>&1 # may not exist
 				if [ "$?" -ne 0 ]; then
 					echo "Holding all jobs for user"
 					condor_hold $DEFUNCT_USER
 				fi
-				which crontab # may not exist, esp in containers
+				which crontab >/dev/null 2>&1 # may not exist, esp in containers
 				if [ "$?" -ne 0 ]; then
 					echo "Removing crons for user"
 					crontab -r -u $DEFUNCT_USER

--- a/resources/provisioner/sync_users.sh
+++ b/resources/provisioner/sync_users.sh
@@ -180,12 +180,17 @@ if [ "$DO_WIPE" ]; then
 		for DEFUNCT_USER in $(cat existing_users); do
 			echo "Deleting user $DEFUNCT_USER"
 			if [ ! "$DRY_RUN" ]; then
-				which condor_hold
+				which condor_hold # may not exist
 				if [ "$?" -ne 0 ]; then
 					echo "Holding all jobs for user"
 					condor_hold $DEFUNCT_USER
 				fi
-				echo "Killing all processes for user and sleeping for 2 seconds"
+				which crontab # may not exist, esp in containers
+				if [ "$?" -ne 0 ]; then
+					echo "Removing crons for user"
+					crontab -r -u $DEFUNCT_USER
+					echo "Killing all processes for user and sleeping for 2 seconds"
+				fi
 				killall -9 -u $DEFUNCT_USER
 				sleep 2
 				$USERDEL "$DEFUNCT_USER"
@@ -378,6 +383,19 @@ $DISABLED_USERS" | sort > all_users
 for DEFUNCT_USER in $(join -v1 existing_users all_users); do
 	echo "Deleting user $DEFUNCT_USER"
 	if [ ! "$DRY_RUN" ]; then
+		which condor_hold # may not exist
+		if [ "$?" -ne 0 ]; then
+			echo "Holding all jobs for user"
+			condor_hold $DEFUNCT_USER
+		fi
+		which crontab # may not exist, esp in containers
+		if [ "$?" -ne 0 ]; then
+			echo "Removing crons for user"
+			crontab -r -u $DEFUNCT_USER
+			echo "Killing all processes for user and sleeping for 2 seconds"
+		fi
+		killall -9 -u $DEFUNCT_USER
+		sleep 2
 		$USERDEL "$DEFUNCT_USER"
 		if [ "$?" -eq 0 ]; then
 			sed '/^'"$DEFUNCT_USER"'$/d' existing_users > existing_users.new

--- a/resources/provisioner/sync_users.sh
+++ b/resources/provisioner/sync_users.sh
@@ -180,6 +180,14 @@ if [ "$DO_WIPE" ]; then
 		for DEFUNCT_USER in $(cat existing_users); do
 			echo "Deleting user $DEFUNCT_USER"
 			if [ ! "$DRY_RUN" ]; then
+				which condor_hold
+				if [ "$?" -ne 0 ]; then
+					echo "Holding all jobs for user"
+					condor_hold $DEFUNCT_USER
+				fi
+				echo "Killing all processes for user and sleeping for 2 seconds"
+				killall -9 -u $DEFUNCT_USER
+				sleep 2
 				$USERDEL "$DEFUNCT_USER"
 				if [ "$?" -ne 0 ]; then
 					echo "Failed to delete user" 1>&2


### PR DESCRIPTION
`userdel` refuses to continue if the user has running processes. 

We remove jobs and kill processes, sleep 2s before trying to userdel. if it doesnt work then we loop back around and try again next time the cron runs.