### PR TITLE
provision MFA tokens based on API resp

### DIFF
--- a/resources/provisioner/sync_users.sh
+++ b/resources/provisioner/sync_users.sh
@@ -814,7 +814,7 @@ for USER in $USERS_TO_UPDATE; do
 	USER_NAME=$(/usr/bin/env echo "$USER_DATA" | jq -r '.name')
 	USER_EMAIL=$(/usr/bin/env echo "$USER_DATA" | jq -r '.email')
 	TOTP_SECRET=$(/usr/bin/env echo "$USER_DATA" | jq -er '.totp_secret')
-	if [ "$?" -ne 0 ];
+	if [ "$?" -ne 0 ]; then
 		echo "No TOTP secret object found - your API server version may not support it"
 	fi
 	RAW_USER_GROUPS=$(/usr/bin/env echo "$USER_DATA" | jq '.group_memberships | map(select(.state==("active","admin")) | .name)' | sed -n 's|.*"'"$BASE_GROUP_CONTEXT"'\([^"]*\)".*|\1|p' | sed -n '/^'"$BASE_GROUP_NAME"'/p')

--- a/resources/provisioner/sync_users.sh
+++ b/resources/provisioner/sync_users.sh
@@ -604,6 +604,7 @@ set_google_authenticator_secret() {
 	USER="$1"
 	USER_HOME_DIR="$2"
 	USER_SECRET_DATA="$3"
+	echo "Creating/updating MFA secrets for $USER"
 	GOOG_AUTH_TMP="$USER_HOME_DIR/.google.authenticator.new"
 	echo "$3" >> $GOOG_AUTH_TMP
 	echo "\" RATE_LIMIT 3 30" >> "$GOOG_AUTH_TMP"

--- a/resources/provisioner/sync_users.sh
+++ b/resources/provisioner/sync_users.sh
@@ -677,7 +677,7 @@ for USER in $USERS_TO_CREATE; do
 	USER_NAME=$(/usr/bin/env echo "$USER_DATA" | jq -r '.name')
 	USER_EMAIL=$(/usr/bin/env echo "$USER_DATA" | jq -r '.email')
 	TOTP_SECRET=$(/usr/bin/env echo "$USER_DATA" | jq -er '.totp_secret')
-	if [ "$?" -ne 0 ];
+	if [ "$?" -ne 0 ]; then
 		echo "No TOTP secret object found - your API server version may not support it"
 	fi
 	RAW_USER_GROUPS=$(/usr/bin/env echo "$USER_DATA" | jq '.group_memberships | map(select(.state==("active","admin")) | .name)' | sed -n 's|.*"'"$BASE_GROUP_CONTEXT"'\([^"]*\)".*|\1|p' | sed -n '/^'"$BASE_GROUP_NAME"'/p')


### PR DESCRIPTION
We look for a token that is not "No TOTP secret" or "null", then push that out to the user's home via the previously defined `set_google_authenticator_secret`.

This is still a WIP and hasn't been tested. 