### PR TITLE
Trim root prefix

### DIFF
--- a/resources/provisioner/sync_users.sh
+++ b/resources/provisioner/sync_users.sh
@@ -356,6 +356,10 @@ BASE_GROUP_CONTEXT=$(/usr/bin/env echo "$GROUP_ROOT_GROUP" | sed -n 's/^\(.*\)\.
 if [ "$BASE_GROUP_CONTEXT" ]; then
 	# demand an explicit dot after a non-empty base
 	BASE_GROUP_CONTEXT="$BASE_GROUP_CONTEXT."
+else
+	# Base group context is empty, set it to root. We never want to make
+	# groups starting with "root."
+	BASE_GROUP_CONTEXT="root."
 fi
 # Get all subgroups
 curl -sf -G -d @token ${API_ENDPOINT}/v1alpha1/groups/${GROUP_ROOT_GROUP}/subgroups > subgroups.json

--- a/resources/provisioner/sync_users.sh
+++ b/resources/provisioner/sync_users.sh
@@ -356,7 +356,7 @@ BASE_GROUP_CONTEXT=$(/usr/bin/env echo "$GROUP_ROOT_GROUP" | sed -n 's/^\(.*\)\.
 if [ "$BASE_GROUP_CONTEXT" ]; then
 	# demand an explicit dot after a non-empty base
 	BASE_GROUP_CONTEXT="$BASE_GROUP_CONTEXT."
-else
+elif [ "$GROUP_ROOT_GROUP" == "root" ]; then
 	# Base group context is empty, set it to root. We never want to make
 	# groups starting with "root."
 	BASE_GROUP_CONTEXT="root."


### PR DESCRIPTION
We never want to create groups like 'root.foo.bar' if the user source group and group root group are simply 'root'. So here's a hack to trim that.

Here's example dry-run output in action with some specific group names stripped out: 
```bash
Creating group cms.org.*** with gid 8376
Group osg.*** already exists
Group osg.*** already exists
Group osg.*** already exists
Creating group atlas.org.*** with gid 9898
Group osg.*** already exists
```