### PR TITLE
Update sync_users.sh

### DIFF
--- a/resources/provisioner/sync_users.sh
+++ b/resources/provisioner/sync_users.sh
@@ -748,7 +748,7 @@ set_ssh_authorized_keys(){
  	# will remain owned by root when moved into place, which would prevent logins.
 	echo "$USER_KEY_DATA" > "$USER_HOME_DIR/.ssh/authorized_keys.new"
  	chmod 0600 "$USER_HOME_DIR/.ssh/authorized_keys.new"
-	chown "$USER": "$USER_HOME_DIR"/.ssh/authorized_keys.new
+	chown "$USER": "$USER_HOME_DIR/.ssh/authorized_keys.new"
 	if [ $? -ne 0 ]; then
 		echo "Could not chown new authorized keys file. Is this user out of quota?"
 		rm -f "$USER_HOME_DIR/.ssh/authorized_keys.new"

--- a/resources/provisioner/sync_users.sh
+++ b/resources/provisioner/sync_users.sh
@@ -759,7 +759,9 @@ set_ssh_authorized_keys(){
    		cmp "$USER_HOME_DIR"/.ssh/authorized_keys.new "$USER_HOME_DIR"/.ssh/authorized_keys > /dev/null 2>&1
      		if [ $? -ne 0 ]; then  
 			mv "$USER_HOME_DIR/.ssh/authorized_keys.new" "$USER_HOME_DIR/.ssh/authorized_keys"
-   		fi
+   		else
+     			rm -f "$USER_HOME_DIR/.ssh/authorized_keys.new"
+		fi
 	fi
 	# Ensure that the SSH dir has the right permissions
 	chmod 0700 "$USER_HOME_DIR/.ssh"


### PR DESCRIPTION
Prevent some unnecessary file changes on NFS, and don't put an authorized keys into place if `chown` fails rather than `chmod` (which probably always succeeds)