### PR TITLE
Silent mode

### DIFF
--- a/include/ServerUtilities.h
+++ b/include/ServerUtilities.h
@@ -86,5 +86,7 @@ std::string to_string(const JSONDocument& json){
 	return buf.GetString();
 }
 
+//Check if a command is intended to be silent and not send email
+bool isSilent(const crow::request& req);
 
 #endif //SLATE_SERVER_UTILITIES_H

--- a/include/ServerUtilities.h
+++ b/include/ServerUtilities.h
@@ -87,6 +87,6 @@ std::string to_string(const JSONDocument& json){
 }
 
 //Check if a command is intended to be silent and not send email
-bool isSilent(const crow::request& req);
+bool silentMode(const crow::request& req);
 
 #endif //SLATE_SERVER_UTILITIES_H

--- a/include/UserCommands.h
+++ b/include/UserCommands.h
@@ -33,7 +33,6 @@ crow::response updateLastUseTime(PersistentStore& store, const crow::request& re
                                  const std::string uID);
                                  
 bool validateSSHKeys(const std::string& keyData);
-bool isSilent(const crow::request& req);
 
 ///\param userID the user whose admin status should be checked
 ///\param groupName the name of the group whose parent groups should be checked 

--- a/include/UserCommands.h
+++ b/include/UserCommands.h
@@ -33,6 +33,7 @@ crow::response updateLastUseTime(PersistentStore& store, const crow::request& re
                                  const std::string uID);
                                  
 bool validateSSHKeys(const std::string& keyData);
+bool isSilent(const crow::request& req);
 
 ///\param userID the user whose admin status should be checked
 ///\param groupName the name of the group whose parent groups should be checked 

--- a/src/ServerUtilities.cpp
+++ b/src/ServerUtilities.cpp
@@ -85,3 +85,14 @@ std::vector<std::string> string_split_columns(const std::string& line, char deli
     }
     return tokens;
 }
+
+// Check if the requester wants "silent" mode to prevent emails from being
+// sent, useful for bulk actions on inactive users
+bool isSilent(const crow::request& req) {
+	bool silent = false;
+	auto value = req.url_params.get("silent");
+	if (value != nullptr && std::string(value) == "true") {
+		silent = true;
+	}
+	return silent;
+}

--- a/src/ServerUtilities.cpp
+++ b/src/ServerUtilities.cpp
@@ -88,7 +88,7 @@ std::vector<std::string> string_split_columns(const std::string& line, char deli
 
 // Check if the requester wants "silent" mode to prevent emails from being
 // sent, useful for bulk actions on inactive users
-bool isSilent(const crow::request& req) {
+bool silentMode(const crow::request& req) {
 	bool silent = false;
 	auto value = req.url_params.get("silent");
 	if (value != nullptr && std::string(value) == "true") {

--- a/src/UserCommands.cpp
+++ b/src/UserCommands.cpp
@@ -690,7 +690,7 @@ crow::response deleteUser(PersistentStore& store, const crow::request& req, cons
 		return crow::response(500,generateError("User account deletion failed"));
 
 	//send email notification
-	if(!isSilent(req)) {
+	if(!silentMode(req)) {
 		EmailClient::Email message;
 		message.fromAddress="noreply@api.ci-connect.net";
 		message.toAddresses={targetUser.email};
@@ -1060,7 +1060,7 @@ crow::response removeUserFromGroup(PersistentStore& store, const crow::request& 
 	if(!success)
 		return crow::response(500,generateError("User removal from Group failed"));
 		
-	if(!isSilent(req)) {
+	if(!silentMode(req)) {
 		if(currentStatus.state==GroupMembership::Pending){
 			EmailClient::Email mail;
 			mail.fromAddress="noreply@api.ci-connect.net";

--- a/src/UserCommands.cpp
+++ b/src/UserCommands.cpp
@@ -58,17 +58,6 @@ crow::response listUsers(PersistentStore& store, const crow::request& req){
 
 //namespace{
 
-// Check if the requester wants "silent" mode to prevent emails from being
-// sent, useful for bulk actions on inactive users
-bool isSilent(const crow::request& req) {
-	bool silent = false;
-	auto value = req.url_params.get("silent");
-	if (value != nullptr && std::string(value) == "true") {
-	    silent = true;
-	}
-	return silent;
-}
-
 ///Check that a string looks like one or more SSH keys. 
 ///Note that this does not validate that the key type(s) claimed is(are) valid,
 ///or that the key data makes any sense. 


### PR DESCRIPTION
This PR adds 'silent mode' to requests, such that actions can be taken without sending emails to users. The impetus for this is for bulk-cleanup of inactive users. 